### PR TITLE
uvsocks의 loop 파라미터가 NULL일때 쓰레드를 생성 했습니다.

### DIFF
--- a/main.c
+++ b/main.c
@@ -413,9 +413,9 @@ main (int    argc,
   main_setup (main_loop);
 
   if (main_get_param (argc, argv))
-    goto fail   ;
+    goto fail;
 
-  main_uvsocks = uvsocks_new (main_loop,
+  main_uvsocks = uvsocks_new (NULL,
                               main_host,
                               main_port,
                               main_user,


### PR DESCRIPTION
`uvsocks_new`의 첫번째 인자 `loop`의 값이 NULL이라면 쓰레드를 생성하도록 했습니다.

